### PR TITLE
fix #6: explicitly create typed list from dynamic

### DIFF
--- a/lib/src/web.dart
+++ b/lib/src/web.dart
@@ -16,8 +16,13 @@ extension SerialExtensions on Serial {
   @JS('requestPort')
   external Object _requestPort();
 
-  Future<List<SerialPort>> getPorts() =>
-      promiseToFuture<List<SerialPort>>(_getPorts());
+  Future<List<SerialPort>> getPorts() async {
+      final dynamic ports = await promiseToFuture(_getPorts());
+      if (ports is List) {
+          return List<SerialPort>.from(ports);
+      }
+      return [];
+  }
 
   Future<SerialPort> requestPort() =>
       promiseToFuture<SerialPort>(_requestPort());


### PR DESCRIPTION
Resolves #6 

I had the same issue as #6 and after some debugging it seems that dart sometimes prefers an explicit cast from an awaited dynamic to `List<SerialPort>`. Not entirely sure why the error happens to be honest, credits for the fix goes to this [SO](https://stackoverflow.com/questions/70613118/how-to-cast-dynamic-to-t-or-listt)