### PR TITLE
feat: add get/set signal methods to serial api & cancel/locked to read streams

### DIFF
--- a/lib/serial.dart
+++ b/lib/serial.dart
@@ -10,5 +10,7 @@ part 'src/flow_control.dart';
 part 'src/parity.dart';
 part 'src/serial_options.dart';
 part 'src/serial_port_info.dart';
+part 'src/signal_options.dart';
+part 'src/signal_state.dart';
 part 'src/stop_bits.dart';
 part 'src/web.dart';

--- a/lib/src/signal_options.dart
+++ b/lib/src/signal_options.dart
@@ -1,0 +1,26 @@
+part of serial;
+
+/// Options for [SignalPortExtensions.setSignals].
+@JS()
+@anonymous
+abstract class _SignalOptions {
+  /// The external constructor.
+  external factory _SignalOptions({
+    bool dataTerminalReady = false,
+    bool requestToSend = false,
+    // bool break = false
+  });
+
+  /// A boolean indicating whether to invoke the operating system to either assert (if true) or de-assert (if false) the "data terminal ready" or "DTR" signal on the serial port.
+  external bool get dataTerminalReady;
+  external set dataTerminalReady(bool v);
+
+  /// A boolean indicating whether to invoke the operating system to either assert (if true) or de-assert (if false) the "request to send" or "RTS" signal on the serial port.
+  external bool get requestToSend;
+  external set requestToSend(bool v);
+
+  /// A boolean indicating whether to invoke the operating system to either assert (if true) or de-assert (if false) the "break" signal on the serial port.
+  // TODO: break is reserved keyword
+  // external bool get break;
+  // external set break(bool v);
+}

--- a/lib/src/signal_state.dart
+++ b/lib/src/signal_state.dart
@@ -1,0 +1,28 @@
+part of serial;
+
+@JS()
+@anonymous
+abstract class SignalState {
+  external factory SignalState({
+    bool? clearToSend,
+    bool? dataCarrierDetect,
+    bool? dataSetReady,
+    bool? ringIndicator,
+  });
+
+  /// A boolean indicating to the other end of a serial connection that is clear to send data.
+  external bool? get clearToSend;
+  external set clearToSend(bool? v);
+
+  /// A boolean that toggles the control signal needed to communicate over a serial connection.
+  external bool? get dataCarrierDetect;
+  external set dataCarrierDetect(bool? v);
+
+  /// A boolean indicating whether the device is ready to send and receive data.
+  external bool? get dataSetReady;
+  external set dataSetReady(bool? v);
+
+  /// A boolean indicating whether a ring signal should be sent down the serial connection.
+  external bool? get ringIndicator;
+  external set ringIndicator(bool? v);
+}

--- a/lib/src/web.dart
+++ b/lib/src/web.dart
@@ -56,6 +56,11 @@ extension SerialPortExtensions on SerialPort {
   @JS('getInfo')
   external SerialPortInfo getInfo();
 
+  @JS('getSignals')
+  external SignalState getSignals();
+  @JS('setSignals')
+  external Object _setSignals(_SignalOptions options);
+
   external WritableStream get writable;
   external ReadableStream get readable;
 
@@ -99,6 +104,21 @@ extension SerialPortExtensions on SerialPort {
 
   //   return info;
   // }
+
+  /// Sets control signals on the port.
+  Future<void> setSignals({
+    bool dataTerminalReady = false,
+    bool requestToSend = false,
+    // bool break = false,
+  }) {
+    final promise = _setSignals(_SignalOptions(
+      dataTerminalReady: dataTerminalReady,
+      requestToSend: requestToSend,
+      // break: break
+    ));
+
+    return promiseToFuture(promise);
+  }
 }
 
 /// Extensions on [WritableStream].
@@ -121,8 +141,16 @@ extension ReadableStreamExtensions on ReadableStream {
   @JS('getReader')
   external ReadableStreamReader _getReader();
 
+  @JS('cancel')
+  external Object _cancel();
+
   @JS('close')
   external Object _close();
+
+  external bool get locked;
+
+  /// Cancels the [ReadableStream].
+  Future<void> cancel() => promiseToFuture(_cancel());
 
   /// Closes the [ReadableStream].
   Future<void> close() => promiseToFuture(_close());
@@ -170,8 +198,14 @@ extension WritableStreamDefaultWriterExtensions on WritableStreamDefaultWriter {
 
 /// Extensions on [ReadableStreamReader].
 extension ReadableStreamReaderExtensions on ReadableStreamReader {
+  @JS('closed')
+  external Object get _closed;
+
   @JS('read')
   external Object _read();
+
+  @JS('cancel')
+  external Object _cancel();
 
   /// Releases the reader’s lock on the corresponding stream.
   /// After the lock is released, the reader is no longer active.
@@ -185,6 +219,8 @@ extension ReadableStreamReaderExtensions on ReadableStreamReader {
   /// be read later by acquiring a new reader.
   external void releaseLock();
 
+  Future<void> get closed => promiseToFuture(_closed);
+
   /// Returns a promise that allows access to the next chunk from the stream’s internal queue, if available.
   ///
   /// - If the chunk does become available, the promise will be fulfilled with an object of the form { value: theChunk, done: false }.
@@ -193,6 +229,9 @@ extension ReadableStreamReaderExtensions on ReadableStreamReader {
   ///
   /// If reading a chunk causes the queue to become empty, more data will be pulled from the underlying source.
   Future<ReadableStreamDefaultReadResult> read() => promiseToFuture(_read());
+
+  /// Cancels the [ReadableStreamReader].
+  Future<void> cancel() => promiseToFuture(_cancel());
 }
 
 /// Extensions on [ReadableStreamDefaultReadResult].


### PR DESCRIPTION
As I needed to be able to set DTS & RTS on my serial ports which can be done by calling https://developer.mozilla.org/en-US/docs/Web/API/SerialPort/setSignals. These APIs were missing. I've also added `readable.locked` & `reader.cancel()` which I needed to be able to break out of an active read/listen loop.

This PR leaves one issue/todo unfortunately, setSignals uses a property `break` which is a reserved keyword ofc in almost any programming language. I tried using maps & plain objects instead of a class but was unable to get that to work for now. So thats still left as a todo unfortunately

These changes will likely also help with #2 and #4
