### PR TITLE
Add locked getter to WritableStream

### DIFF
--- a/lib/src/web.dart
+++ b/lib/src/web.dart
@@ -134,6 +134,8 @@ extension WritableStreamExtensions on WritableStream {
   @JS('close')
   external Object _close();
 
+  external bool get locked;
+
   /// Closes the [WritableStream].
   Future<void> close() => promiseToFuture(_close());
 


### PR DESCRIPTION
This lets us determine if the WritableStream is locked, so we can unlock it or abort the stream. This allows the port to be closed and re-opened in the same session. 
For example:
```dart
@override
Future<bool> closePort() async {
  if (_serialPort != null) {
    try {
      if (_serialPort!.readable.locked) {
        read = false;
        await reader?.cancel();
      }
      if (_serialPort!.writable.locked) {
        try {
          writer?.releaseLock();
          if (_serialPort!.writable.locked) {
            await writer?.abort();
          }
        } catch (e) {
          await writer?.abort();
        }
      }

      await _serialPort?.close();
    } catch (e) {
      await _serialPort?.close();
      return false;
    } finally {
      writer = null;
      reader = null;
    }
  }
  return true;
}
```